### PR TITLE
Location of JDBC drivers has to be /usr/lib/oozie/lib

### DIFF
--- a/manifests/server/config.pp
+++ b/manifests/server/config.pp
@@ -10,9 +10,9 @@ class oozie::server::config {
     default    => undef,
   }
   $jdbc_dst = $::oozie::db ? {
-    'mysql'      => '/var/lib/oozie/mysql-connector-java.jar',
-    'mariadb'    => '/var/lib/oozie/mysql-connector-java.jar',
-    'postgresql' => '/var/lib/oozie/postgresql.jar',
+    'mysql'      => '/usr/lib/oozie/lib/mysql-connector-java.jar',
+    'mariadb'    => '/usr/lib/oozie/lib/mysql-connector-java.jar',
+    'postgresql' => '/usr/lib/oozie/lib/postgresql.jar',
     default    => undef,
   }
 


### PR DESCRIPTION
Cloudera CDH 6.1.0 on CentOS 7.6 needed this change for the JDBC driver to end up in CLASSPATH. Not sure if it's an error or if it's distribution dependent. 